### PR TITLE
disable IPS_LogMessage output

### DIFF
--- a/Netatmo/module.php
+++ b/Netatmo/module.php
@@ -171,7 +171,7 @@ require_once (__ROOT__.'/Netatmo/src/Netatmo/autoload.php');
         			}
     			}			
 		}
-		IPS_LogMessage('Netatmo_Modul', $echoString);
+		//IPS_LogMessage('Netatmo_Modul', $echoString);
 		echo "done...siehe Logs";
 	}
 	
@@ -200,12 +200,12 @@ require_once (__ROOT__.'/Netatmo/src/Netatmo/autoload.php');
 		catch(NAClientException $ex)
 		{
 			 $this->handleError("An error occured while retrieving data: ". $ex->getMessage()."\n", TRUE);
-			 IPS_LogMessage('Netatmo_Modul', "An error occured while retrieving data: ". $ex->getMessage()."\n");
+			 //IPS_LogMessage('Netatmo_Modul', "An error occured while retrieving data: ". $ex->getMessage()."\n");
 		}
 		if(empty($data['devices']))
 		{
     			$this->echoLog( 'No devices affiliated to user');
-    			IPS_LogMessage('Netatmo_Modul', $echoString);
+    			//IPS_LogMessage('Netatmo_Modul', $echoString);
 		}
 		else
 		{
@@ -224,7 +224,7 @@ require_once (__ROOT__.'/Netatmo/src/Netatmo/autoload.php');
                 		$this->saveModules($module);
         		}
 		}
-		IPS_LogMessage('Netatmo_Modul', "GetData finished successfully");
+		//IPS_LogMessage('Netatmo_Modul', "GetData finished successfully");
 	}
 
 	private function getModuleName($device)
@@ -498,7 +498,7 @@ require_once (__ROOT__.'/Netatmo/src/Netatmo/autoload.php');
 
 	private function handleError($message, $exit = FALSE)
 	{
-		IPS_LogMessage('Netatmo_ERROR', $message);
+		//IPS_LogMessage('Netatmo_ERROR', $message);
     		if($exit)
     		{
         		exit(-1);


### PR DESCRIPTION
Alle Meldungen von IPS_LogMessage landen im Message Log und werden farblich hinterlegt. Dadurch kann es ggf. sehr unübersichtlich werden. Die präferierte Lösung ist Mittlerweile SendDebug, auf die man umsteigen könnten. Fürs erste würde aber reichen, wenn wir die paar übrigens Meldungen erstmal deaktivieren :)

Beispiel für Diskussion im Forum: https://www.symcon.de/forum/threads/37341
Ab IP-Symcon 5.0 gibt es zusätzlich ein Widget, welches Meldungen die nicht "weiß" sind bemängelt und anzeigt, sodass diese auch spürbarer werden.

Wäre cool, wenn du den PR mergen könntest!